### PR TITLE
Add points/shapes highlight color setting to Appereance settings and preference page

### DIFF
--- a/napari/_qt/dialogs/preferences_dialog.py
+++ b/napari/_qt/dialogs/preferences_dialog.py
@@ -27,7 +27,7 @@ class PreferencesDialog(QDialog):
 
     ui_schema: ClassVar[Dict[str, Dict[str, str]]] = {
         'call_order': {'ui:widget': 'plugins'},
-        'highlight_thickness': {'ui:widget': 'highlight'},
+        'highlight': {'ui:widget': 'highlight'},
         'shortcuts': {'ui:widget': 'shortcuts'},
         'extension2reader': {'ui:widget': 'extension2reader'},
         'dask': {'ui:widget': 'horizontal_object'},

--- a/napari/_qt/widgets/_tests/test_qt_highlight_preview.py
+++ b/napari/_qt/widgets/_tests/test_qt_highlight_preview.py
@@ -1,7 +1,8 @@
+import numpy as np
 import pytest
 
 from napari._qt.widgets.qt_highlight_preview import (
-    QtHighlightSizePreviewWidget,
+    QtHighlightPreviewWidget,
     QtStar,
     QtTriangle,
 )
@@ -32,15 +33,15 @@ def triangle_widget(qtbot):
 
 
 @pytest.fixture
-def highlight_size_preview_widget(qtbot):
-    def _highlight_size_preview_widget(**kwargs):
-        widget = QtHighlightSizePreviewWidget(**kwargs)
+def highlight_preview_widget(qtbot):
+    def _highlight_preview_widget(**kwargs):
+        widget = QtHighlightPreviewWidget(**kwargs)
         widget.show()
         qtbot.addWidget(widget)
 
         return widget
 
-    return _highlight_size_preview_widget
+    return _highlight_preview_widget
 
 
 # QtStar
@@ -110,130 +111,169 @@ def test_qt_triangle_signal(qtbot, triangle_widget):
         widget.setValue(-5)
 
 
-# QtHighlightSizePreviewWidget
+# QtHighlightPreviewWidget
 # ----------------------------------------------------------------------------
 
 
-def test_qt_highlight_size_preview_widget_defaults(
-    highlight_size_preview_widget,
+def test_qt_highlight_preview_widget_defaults(
+    highlight_preview_widget,
 ):
-    highlight_size_preview_widget()
+    highlight_preview_widget()
 
 
-def test_qt_highlight_size_preview_widget_description(
-    highlight_size_preview_widget,
+def test_qt_highlight_preview_widget_description(
+    highlight_preview_widget,
 ):
     description = 'Some text'
-    widget = highlight_size_preview_widget(description=description)
+    widget = highlight_preview_widget(description=description)
     assert widget.description() == description
 
-    widget = highlight_size_preview_widget()
+    widget = highlight_preview_widget()
     widget.setDescription(description)
     assert widget.description() == description
 
 
-def test_qt_highlight_size_preview_widget_unit(highlight_size_preview_widget):
+def test_qt_highlight_preview_widget_unit(highlight_preview_widget):
     unit = 'CM'
-    widget = highlight_size_preview_widget(unit=unit)
+    widget = highlight_preview_widget(unit=unit)
     assert widget.unit() == unit
 
-    widget = highlight_size_preview_widget()
+    widget = highlight_preview_widget()
     widget.setUnit(unit)
     assert widget.unit() == unit
 
 
-def test_qt_highlight_size_preview_widget_minimum(
-    highlight_size_preview_widget,
+def test_qt_highlight_preview_widget_minimum(
+    highlight_preview_widget,
 ):
     minimum = 5
-    widget = highlight_size_preview_widget(min_value=minimum)
+    widget = highlight_preview_widget(min_value=minimum)
     assert widget.minimum() == minimum
-    assert widget.value() >= minimum
+    assert widget._thickness_value >= minimum
+    assert widget.value()['highlight_thickness'] >= minimum
 
-    widget = highlight_size_preview_widget()
+    widget = highlight_preview_widget()
     widget.setMinimum(3)
     assert widget.minimum() == 3
-    assert widget.value() == 3
+    assert widget._thickness_value == 3
+    assert widget.value()['highlight_thickness'] == 3
     assert widget._slider.minimum() == 3
     assert widget._slider_min_label.text() == '3'
     assert widget._triangle.minimum() == 3
     assert widget._lineedit.text() == '3'
 
 
-def test_qt_highlight_size_preview_widget_minimum_invalid(
-    highlight_size_preview_widget,
+def test_qt_highlight_preview_widget_minimum_invalid(
+    highlight_preview_widget,
 ):
-    widget = highlight_size_preview_widget()
+    widget = highlight_preview_widget()
 
     with pytest.raises(ValueError):
         widget.setMinimum(60)
 
 
-def test_qt_highlight_size_preview_widget_maximum(
-    highlight_size_preview_widget,
+def test_qt_highlight_preview_widget_maximum(
+    highlight_preview_widget,
 ):
     maximum = 10
-    widget = highlight_size_preview_widget(max_value=maximum)
+    widget = highlight_preview_widget(max_value=maximum)
 
     assert widget.maximum() == maximum
-    assert widget.value() <= maximum
+    assert widget._thickness_value <= maximum
+    assert widget.value()['highlight_thickness'] <= maximum
 
-    widget = highlight_size_preview_widget()
+    widget = highlight_preview_widget(
+        value={
+            'highlight_thickness': 6,
+            'highlight_color': [0.0, 0.6, 1.0, 1.0],
+        }
+    )
     widget.setMaximum(20)
     assert widget.maximum() == 20
     assert widget._slider.maximum() == 20
     assert widget._triangle.maximum() == 20
     assert widget._slider_max_label.text() == '20'
 
+    assert widget._thickness_value == 6
+    assert widget.value()['highlight_thickness'] == 6
     widget.setMaximum(5)
     assert widget.maximum() == 5
-    # assert widget.value() == 5
-    # assert widget._slider.maximum() == 5
-    # assert widget._triangle.maximum() == 20
-    # assert widget._lineedit.text() == "5"
-    # assert widget._slider_max_label.text() == "5"
+    assert widget._thickness_value == 5
+    assert widget.value()['highlight_thickness'] == 5
+    assert widget._slider.maximum() == 5
+    assert widget._triangle.maximum() == 5
+    assert widget._lineedit.text() == '5'
+    assert widget._slider_max_label.text() == '5'
 
 
-def test_qt_highlight_size_preview_widget_maximum_invalid(
-    highlight_size_preview_widget,
+def test_qt_highlight_preview_widget_maximum_invalid(
+    highlight_preview_widget,
 ):
-    widget = highlight_size_preview_widget()
+    widget = highlight_preview_widget()
 
     with pytest.raises(ValueError):
         widget.setMaximum(-5)
 
 
-def test_qt_highlight_size_preview_widget_value(highlight_size_preview_widget):
-    widget = highlight_size_preview_widget(value=5)
-    assert widget.value() <= 5
+def test_qt_highlight_preview_widget_value(highlight_preview_widget):
+    widget = highlight_preview_widget(
+        value={
+            'highlight_thickness': 5,
+            'highlight_color': [0.0, 0.6, 1.0, 1.0],
+        }
+    )
+    assert widget._thickness_value <= 5
+    assert widget.value()['highlight_thickness'] <= 5
+    assert widget._color_value == [0.0, 0.6, 1.0, 1.0]
+    assert widget.value()['highlight_color'] == [0.0, 0.6, 1.0, 1.0]
 
-    widget = highlight_size_preview_widget()
-    widget.setValue(5)
-    assert widget.value() == 5
+    widget = highlight_preview_widget()
+    widget.setValue(
+        {'highlight_thickness': 5, 'highlight_color': [0.6, 0.6, 1.0, 1.0]}
+    )
+    assert widget._thickness_value == 5
+    assert widget.value()['highlight_thickness'] == 5
+    assert np.array_equal(
+        np.array(widget._color_value, dtype=np.float32),
+        np.array([0.6, 0.6, 1.0, 1.0], dtype=np.float32),
+    )
+    assert np.array_equal(
+        np.array(widget.value()['highlight_color'], dtype=np.float32),
+        np.array([0.6, 0.6, 1.0, 1.0], dtype=np.float32),
+    )
 
 
-def test_qt_highlight_size_preview_widget_value_invalid(
-    qtbot, highlight_size_preview_widget
+def test_qt_highlight_preview_widget_value_invalid(
+    qtbot, highlight_preview_widget
 ):
-    widget = highlight_size_preview_widget()
+    widget = highlight_preview_widget()
     widget.setMaximum(50)
-    widget.setValue(51)
-    assert widget.value() == 50
+    widget.setValue(
+        {'highlight_thickness': 51, 'highlight_color': [0.0, 0.6, 1.0, 1.0]}
+    )
+    assert widget.value()['highlight_thickness'] == 50
     assert widget._lineedit.text() == '50'
 
     widget.setMinimum(5)
-    widget.setValue(1)
-    assert widget.value() == 5
+    widget.setValue(
+        {'highlight_thickness': 1, 'highlight_color': [0.0, 0.6, 1.0, 1.0]}
+    )
+    assert widget.value()['highlight_thickness'] == 5
     assert widget._lineedit.text() == '5'
 
 
-def test_qt_highlight_size_preview_widget_signal(
-    qtbot, highlight_size_preview_widget
-):
-    widget = highlight_size_preview_widget()
+def test_qt_highlight_preview_widget_signal(qtbot, highlight_preview_widget):
+    widget = highlight_preview_widget()
 
     with qtbot.waitSignal(widget.valueChanged, timeout=500):
-        widget.setValue(7)
+        widget.setValue(
+            {'highlight_thickness': 7, 'highlight_color': [0.0, 0.6, 1.0, 1.0]}
+        )
 
     with qtbot.waitSignal(widget.valueChanged, timeout=500):
-        widget.setValue(-5)
+        widget.setValue(
+            {
+                'highlight_thickness': -5,
+                'highlight_color': [0.0, 0.6, 1.0, 1.0],
+            }
+        )

--- a/napari/_qt/widgets/qt_highlight_preview.py
+++ b/napari/_qt/widgets/qt_highlight_preview.py
@@ -13,6 +13,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
+from napari._qt.widgets.qt_color_swatch import QColorSwatchEdit
 from napari.utils.translations import translator
 
 trans = translator.load()
@@ -34,6 +35,7 @@ class QtStar(QFrame):
     ) -> None:
         super().__init__(parent)
         self._value = value
+        self._color = QColor(135, 206, 235)
 
     def sizeHint(self):
         """Override Qt sizeHint."""
@@ -62,7 +64,7 @@ class QtStar(QFrame):
         """
         return self._value
 
-    def setValue(self, value: int):
+    def setValue(self, value: int, color: QColor = None):
         """Set line width value of star widget.
 
         Parameters
@@ -72,6 +74,8 @@ class QtStar(QFrame):
         """
 
         self._value = value
+        if color is not None:
+            self._color = color
         self.update()
 
     def drawStar(self, qp):
@@ -83,7 +87,7 @@ class QtStar(QFrame):
         """
         width = self.rect().width()
         height = self.rect().height()
-        col = QColor(135, 206, 235)
+        col = self._color
         pen = QPen(col, self._value)
         pen.setJoinStyle(Qt.PenJoinStyle.MiterJoin)
         qp.setPen(pen)
@@ -149,6 +153,7 @@ class QtTriangle(QFrame):
         self._max_value = max_value
         self._min_value = min_value
         self._value = value
+        self._color = QColor(135, 206, 235)
 
     def mousePressEvent(self, event):
         """When mouse is clicked, adjust to new values."""
@@ -185,7 +190,7 @@ class QtTriangle(QFrame):
         """
         width = self.rect().width()
 
-        col = QColor(135, 206, 235)
+        col = self._color
         qp.setPen(QPen(col, 1))
         qp.setBrush(col)
         path = QPainterPath()
@@ -210,7 +215,7 @@ class QtTriangle(QFrame):
         """
         return self._value
 
-    def setValue(self, value):
+    def setValue(self, value, color=None):
         """Set value for triangle widget.
 
         Parameters
@@ -219,6 +224,8 @@ class QtTriangle(QFrame):
             Value to use for line in triangle widget.
         """
         self._value = value
+        if color is not None:
+            self._color = color
         self.update()
 
     def minimum(self):
@@ -286,7 +293,7 @@ class QtTriangle(QFrame):
         self.valueChanged.emit(self._value)
 
 
-class QtHighlightSizePreviewWidget(QWidget):
+class QtHighlightPreviewWidget(QWidget):
     """Creates custom widget to set highlight size.
 
     Parameters
@@ -303,13 +310,13 @@ class QtHighlightSizePreviewWidget(QWidget):
         Unit of highlight size.
     """
 
-    valueChanged = Signal(int)
+    valueChanged = Signal(dict)
 
     def __init__(
         self,
         parent: QWidget = None,
         description: str = '',
-        value: int = 1,
+        value: Optional[dict] = None,
         min_value: int = 1,
         max_value: int = 10,
         unit: str = 'px',
@@ -317,11 +324,23 @@ class QtHighlightSizePreviewWidget(QWidget):
         super().__init__(parent)
 
         self.setGeometry(300, 300, 125, 110)
-        self._value = value or self.fontMetrics().height()
+        if value is None:
+            value = {
+                'highlight_thickness': 1,
+                'highlight_color': [0.0, 0.6, 1.0, 1.0],
+            }
+        self._value = value
+        self._thickness_value = (
+            value['highlight_thickness'] or self.fontMetrics().height()
+        )
+        self._color_value = value['highlight_color'] or [0.0, 0.6, 1.0, 1.0]
         self._min_value = min_value
         self._max_value = max_value
 
         # Widget
+        self._color_swatch_edit = QColorSwatchEdit(
+            self, initial_color=self._color_value
+        )
         self._lineedit = QLineEdit()
         self._description = QLabel(self)
         self._unit = QLabel(self)
@@ -347,8 +366,8 @@ class QtHighlightSizePreviewWidget(QWidget):
         self._slider_max_label.setAlignment(Qt.AlignmentFlag.AlignBottom)
         self._slider.setMinimum(min_value)
         self._slider.setMaximum(max_value)
-        self._preview.setValue(value)
-        self._triangle.setValue(value)
+        self._preview.setValue(self._thickness_value)
+        self._triangle.setValue(self._thickness_value)
         self._triangle.setMinimum(min_value)
         self._triangle.setMaximum(max_value)
         self._preview_label.setText(trans._('Preview'))
@@ -357,9 +376,10 @@ class QtHighlightSizePreviewWidget(QWidget):
         self._preview.setStyleSheet('border: 1px solid white;')
 
         # Signals
-        self._slider.valueChanged.connect(self._update_value)
-        self._lineedit.textChanged.connect(self._update_value)
-        self._triangle.valueChanged.connect(self._update_value)
+        self._slider.valueChanged.connect(self._update_thickness_value)
+        self._lineedit.textChanged.connect(self._update_thickness_value)
+        self._triangle.valueChanged.connect(self._update_thickness_value)
+        self._color_swatch_edit.color_changed.connect(self._update_color_value)
 
         # Layout
         triangle_layout = QHBoxLayout()
@@ -372,7 +392,8 @@ class QtHighlightSizePreviewWidget(QWidget):
         triangle_slider_layout.setAlignment(Qt.AlignmentFlag.AlignVCenter)
 
         # Bottom row layout
-        lineedit_layout = QHBoxLayout()
+        lineedit_layout = QVBoxLayout()
+        lineedit_layout.addWidget(self._color_swatch_edit)
         lineedit_layout.addWidget(self._lineedit)
         lineedit_layout.setAlignment(Qt.AlignmentFlag.AlignBottom)
         bottom_left_layout = QHBoxLayout()
@@ -405,31 +426,56 @@ class QtHighlightSizePreviewWidget(QWidget):
 
         self._refresh()
 
-    def _update_value(self, value):
-        """Update highlight value.
+    def _update_thickness_value(self, thickness_value):
+        """Update highlight thickness value.
 
         Parameters
         ----------
-        value : int
-            Highlight value.
+        thickness_value : int
+            Highlight thickness value.
         """
-        if value == '':
+        if thickness_value == '':
             return
-        value = int(value)
-        value = max(min(value, self._max_value), self._min_value)
-        if value == self._value:
+        thickness_value = int(thickness_value)
+        thickness_value = max(
+            min(thickness_value, self._max_value), self._min_value
+        )
+        if thickness_value == self._thickness_value:
             return
-        self._value = value
+        self._thickness_value = thickness_value
+        self._value['highlight_thickness'] = self._thickness_value
+        self.valueChanged.emit(self._value)
+        self._refresh()
+
+    def _update_color_value(self, color_value):
+        """Update highlight color value.
+
+        Parameters
+        ----------
+        color_value : List[float]
+            Highlight color value as a list of floats.
+        """
+        if isinstance(color_value, np.ndarray):
+            color_value = color_value.tolist()
+        if color_value == self._color_value:
+            return
+        self._color_value = color_value
+        self._value['highlight_color'] = self._color_value
         self.valueChanged.emit(self._value)
         self._refresh()
 
     def _refresh(self):
         """Set every widget value to the new set value."""
         self.blockSignals(True)
-        self._lineedit.setText(str(self._value))
-        self._slider.setValue(self._value)
-        self._triangle.setValue(self._value)
-        self._preview.setValue(self._value)
+        # Transform color value from a float representation
+        # (values from 0.0 to 1.0) to RGB values (values from 0 to 255)
+        # to set widgets color.
+        color = QColor(*[int(np.ceil(v * 255)) for v in self._color_value[:3]])
+        self._lineedit.setText(str(self._thickness_value))
+        self._slider.setValue(self._thickness_value)
+        self._triangle.setValue(self._thickness_value, color=color)
+        self._preview.setValue(self._thickness_value, color=color)
+        self._color_swatch_edit.setColor(self._color_value)
         self.blockSignals(False)
 
     def value(self):
@@ -437,20 +483,21 @@ class QtHighlightSizePreviewWidget(QWidget):
 
         Returns
         -------
-        int
-            Current value of highlight widget.
+        dict
+            Current value of highlight widget (thickness and color).
         """
         return self._value
 
-    def setValue(self, value):
+    def setValue(self, value: dict):
         """Set new value and update widget.
 
         Parameters
         ----------
-        value : int
-            Highlight value.
+        value : dict
+            Highlight value (thickness and color).
         """
-        self._update_value(value)
+        self._update_thickness_value(value['highlight_thickness'])
+        self._update_color_value(value['highlight_color'])
         self._refresh()
 
     def description(self):
@@ -514,7 +561,10 @@ class QtHighlightSizePreviewWidget(QWidget):
         self._slider_min_label.setText(str(value))
         self._slider.setMinimum(value)
         self._triangle.setMinimum(value)
-        self._value = max(self._value, self._min_value)
+        self._thickness_value = max(
+            self._value['highlight_thickness'], self._min_value
+        )
+        self._value['highlight_thickness'] = self._thickness_value
         self._refresh()
 
     def minimum(self):
@@ -548,7 +598,10 @@ class QtHighlightSizePreviewWidget(QWidget):
         self._slider_max_label.setText(str(value))
         self._slider.setMaximum(value)
         self._triangle.setMaximum(value)
-        self._value = min(self._value, self._max_value)
+        self._thickness_value = min(
+            self._value['highlight_thickness'], self._max_value
+        )
+        self._value['highlight_thickness'] = self._thickness_value
         self._refresh()
 
     def maximum(self):

--- a/napari/_vendor/qt_json_builder/qt_jsonschema_form/form.py
+++ b/napari/_vendor/qt_json_builder/qt_jsonschema_form/form.py
@@ -29,6 +29,7 @@ class WidgetBuilder:
             "plugins": widgets.PluginWidget,
             "shortcuts": widgets.ShortcutsWidget,
             "extension2reader": widgets.Extension2ReaderWidget,
+            "highlight": widgets.HighlightPreviewWidget,
         },
         "number": {
             "spin": widgets.SpinDoubleSchemaWidget,
@@ -48,7 +49,6 @@ class WidgetBuilder:
             "text": widgets.TextSchemaWidget,
             "range": widgets.IntegerRangeSchemaWidget,
             "enum": widgets.EnumSchemaWidget,
-            "highlight": widgets.HighlightSizePreviewWidget,
             "font_size": widgets.FontSizeSchemaWidget,
         },
         "array": {

--- a/napari/_vendor/qt_json_builder/qt_jsonschema_form/widgets.py
+++ b/napari/_vendor/qt_json_builder/qt_jsonschema_form/widgets.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional, TYPE_CHECKING, Tuple
 from qtpy import QtCore, QtGui, QtWidgets
 
 from ...._qt.widgets.qt_extension2reader import Extension2ReaderTable
-from ...._qt.widgets.qt_highlight_preview import QtHighlightSizePreviewWidget
+from ...._qt.widgets.qt_highlight_preview import QtHighlightPreviewWidget
 from ...._qt.widgets.qt_keyboard_settings import ShortcutEditor
 from ...._qt.widgets.qt_font_size import QtFontSizeWidget
 
@@ -585,18 +585,18 @@ class ArraySchemaWidget(SchemaWidgetMixin, QtWidgets.QWidget):
         self.on_changed.emit(self.state)
 
 
-class HighlightSizePreviewWidget(
-    SchemaWidgetMixin, QtHighlightSizePreviewWidget
+class HighlightPreviewWidget(
+    SchemaWidgetMixin, QtHighlightPreviewWidget
 ):
     @state_property
-    def state(self) -> int:
+    def state(self) -> dict:
         return self.value()
 
     def setDescription(self, description: str):
         self._description.setText(description)
 
     @state.setter
-    def state(self, state: int):
+    def state(self, state: dict):
         self.setValue(state)
 
     def configure(self):

--- a/napari/_vispy/layers/points.py
+++ b/napari/_vispy/layers/points.py
@@ -10,7 +10,6 @@ from napari.utils.events import disconnect_events
 
 
 class VispyPointsLayer(VispyBaseLayer):
-    _highlight_color = (0, 0.6, 1)
     node: PointsVisual
 
     def __init__(self, layer) -> None:
@@ -113,15 +112,17 @@ class VispyPointsLayer(VispyBaseLayer):
 
         scale = self.layer.scale[-1]
         scaled_highlight = (
-            settings.appearance.highlight_thickness * self.layer.scale_factor
+            settings.appearance.highlight.highlight_thickness
+            * self.layer.scale_factor
         )
+        highlight_color = tuple(settings.appearance.highlight.highlight_color)
 
         self.node.selection_markers.set_data(
             data[:, ::-1],
             size=(size + border_width) * scale,
             symbol=symbol,
             edge_width=scaled_highlight * 2,
-            edge_color=self._highlight_color,
+            edge_color=highlight_color,
             face_color=transform_color('transparent'),
         )
 
@@ -137,7 +138,7 @@ class VispyPointsLayer(VispyBaseLayer):
 
         self.node.highlight_lines.set_data(
             pos=pos[:, ::-1],
-            color=self._highlight_color,
+            color=highlight_color,
             width=width,
         )
 

--- a/napari/_vispy/layers/shapes.py
+++ b/napari/_vispy/layers/shapes.py
@@ -61,7 +61,12 @@ class VispyShapesLayer(VispyBaseLayer):
 
     def _on_highlight_change(self):
         settings = get_settings()
-        self.layer._highlight_width = settings.appearance.highlight_thickness
+        self.layer._highlight_width = (
+            settings.appearance.highlight.highlight_thickness
+        )
+        self.layer._highlight_color = (
+            settings.appearance.highlight.highlight_color
+        )
 
         # Compute the vertices and faces of any shape outlines
         vertices, faces = self.layer._outline_shapes()
@@ -86,7 +91,7 @@ class VispyShapesLayer(VispyBaseLayer):
             _,
         ) = self.layer._compute_vertices_and_box()
 
-        width = settings.appearance.highlight_thickness
+        width = settings.appearance.highlight.highlight_thickness
 
         if vertices is None or len(vertices) == 0:
             vertices = np.zeros((1, self.layer._slice_input.ndisplay))

--- a/napari/settings/_appearance.py
+++ b/napari/settings/_appearance.py
@@ -1,10 +1,29 @@
-from typing import Union, cast
+from typing import List, Union, cast
 
 from napari._pydantic_compat import Field
 from napari.settings._fields import Theme
 from napari.utils.events.evented_model import ComparisonDelayer, EventedModel
 from napari.utils.theme import available_themes, get_theme
 from napari.utils.translations import trans
+
+
+class HighlightSettings(EventedModel):
+    highlight_thickness: int = Field(
+        1,
+        title=trans._('Highlight thickness'),
+        description=trans._(
+            'Select the highlight thickness when hovering over shapes/points.'
+        ),
+        ge=1,
+        le=10,
+    )
+    highlight_color: List[float] = Field(
+        [0.0, 0.6, 1.0, 1.0],
+        title=trans._('Highlight color'),
+        description=trans._(
+            'Select the highlight color when hovering over shapes/points.'
+        ),
+    )
 
 
 class AppearanceSettings(EventedModel):
@@ -21,14 +40,12 @@ class AppearanceSettings(EventedModel):
         ge=5,
         le=20,
     )
-    highlight_thickness: int = Field(
-        1,
-        title=trans._('Highlight thickness'),
+    highlight: HighlightSettings = Field(
+        HighlightSettings(),
+        title=trans._('Highlight'),
         description=trans._(
-            'Select the highlight thickness when hovering over shapes/points.'
+            'Select the highlight color and thickness to use when hovering over shapes/points.'
         ),
-        ge=1,
-        le=10,
     )
     layer_tooltip_visibility: bool = Field(
         False,


### PR DESCRIPTION
Recreated from original PR: https://github.com/napari/napari/pull/6689

# References and relevant issues

Closes #1035 

# Description

Add a way to set highlight color for points/shapes from the preferences/app config. A preview:

![highlight](https://github.com/napari/napari/assets/16781833/83ffcd15-35b0-44ab-8a58-f5ae2a8bc023)


